### PR TITLE
Example of how to find random locations and spawn bank notes.

### DIFF
--- a/Make It Rain.xcodeproj/project.pbxproj
+++ b/Make It Rain.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7E4FRN2QG2;
+				DEVELOPMENT_TEAM = HY8AUX8L27;
 				INFOPLIST_FILE = "Make It Rain/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -465,7 +465,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7E4FRN2QG2;
+				DEVELOPMENT_TEAM = HY8AUX8L27;
 				INFOPLIST_FILE = "Make It Rain/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Fixed bank note spawn implementation. This is just one way to do it. Includes an example of how to address z-fighting.

You should also turn off / lock your plane detection or hide it once you "make it rain".

There seem to be some other issues when the AR scene loads that causes the app to have a black screen for a few seconds. Did not debug this.